### PR TITLE
feat: Add option to disable editors

### DIFF
--- a/.changeset/wicked-rings-tease.md
+++ b/.changeset/wicked-rings-tease.md
@@ -1,0 +1,5 @@
+---
+"@guardian/prosemirror-editor": minor
+---
+
+Add option to disable editors

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -10,6 +10,10 @@
     padding: 10px;
 }
 
+.ProseMirror[contenteditable="false"]{
+    background-color: #f6f6f6;
+    cursor: not-allowed
+}
 
 .ProseMirror p {
     margin: 0px

--- a/src/ts/RichTextEditor.tsx
+++ b/src/ts/RichTextEditor.tsx
@@ -13,9 +13,10 @@ interface RichTextEditorProps {
   config: EditorConfig;
   label?: string;
   shouldAcceptCopiedText?: boolean;
+  disabled: boolean;
 }
 
-export const RichTextEditor = ({ value, onUpdate, config, label, shouldAcceptCopiedText = false }: RichTextEditorProps) => {
+export const RichTextEditor = ({ value, onUpdate, config, label, shouldAcceptCopiedText = false, disabled }: RichTextEditorProps) => {
   const schema = createSchema(config);
 
   const editorEl = useRef<HTMLDivElement>(null);
@@ -33,7 +34,7 @@ export const RichTextEditor = ({ value, onUpdate, config, label, shouldAcceptCop
     // Editor view takes an HTML Node therefore this string value needs to be converted into a node by placing in a div
     const contentNode = document.createElement('div');
     contentNode.innerHTML = value;
-    const edView = createEditorView(localOnUpdate, editorEl, contentNode, schema, config);
+    const edView = createEditorView(localOnUpdate, editorEl, contentNode, schema, config, disabled);
     setEditorView(edView);
   }, []);
 

--- a/src/ts/RichTextEditor.tsx
+++ b/src/ts/RichTextEditor.tsx
@@ -16,7 +16,7 @@ interface RichTextEditorProps {
   disabled: boolean;
 }
 
-export const RichTextEditor = ({ value, onUpdate, config, label, shouldAcceptCopiedText = false, disabled }: RichTextEditorProps) => {
+export const RichTextEditor = ({ value, onUpdate, config, label, shouldAcceptCopiedText = false, disabled = false }: RichTextEditorProps) => {
   const schema = createSchema(config);
 
   const editorEl = useRef<HTMLDivElement>(null);

--- a/src/ts/richtext/setup.ts
+++ b/src/ts/richtext/setup.ts
@@ -25,7 +25,8 @@ export const createEditorView = (
   editorEl: RefObject<HTMLDivElement>,
   contentEl: HTMLDivElement,
   schema: Schema,
-  config: EditorConfig
+  config: EditorConfig,
+  disabled: boolean
 ) => {
   if (!editorEl.current) {
     return;
@@ -49,7 +50,10 @@ export const createEditorView = (
         tmp.appendChild(outputHtml);
         onChange(tmp.innerHTML);
       }
-    }
+    },
+    editable: () => {
+      return !disabled;
+    },
   });
   return ed;
 };

--- a/src/ts/richtext/setup.ts
+++ b/src/ts/richtext/setup.ts
@@ -10,14 +10,14 @@ import { buildMenuItems } from './menu';
 import { baseKeymap } from 'prosemirror-commands';
 import { EditorConfig } from './config';
 
-const createBasePlugins = (schema: Schema, config: EditorConfig) => {
+const createBasePlugins = (schema: Schema, config: EditorConfig, disabled: boolean) => {
   const plugins = [
     keymap(buildKeymap(schema, {}, {}, config)),
     keymap(baseKeymap),
     history({ depth: 100, newGroupDelay: 500 }),
     menuBar({content: buildMenuItems(schema)})
   ];
-  return plugins;
+  return disabled ? [] : plugins;
 };
 
 export const createEditorView = (
@@ -36,7 +36,7 @@ export const createEditorView = (
       doc: DOMParser.fromSchema(schema).parse(contentEl, {
         preserveWhitespace: true
       }),
-      plugins: createBasePlugins(schema, config)
+      plugins: createBasePlugins(schema, config, disabled)
     }),
     dispatchTransaction: (transaction: Transaction) => {
       const { state, transactions } = ed.state.applyTransaction(transaction);


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?
This adds support for a `disabled` prop to the `RichTextEditor`.

If the editor is disabled, it's styled differently, the editor content can't be changed, and the menu and keyboard shortcut plugins won't be initialised. The field will instead appear as uneditable text, showing a `not-allowed` cursor on hover.

This is useful in our apps, where a field will often be disabled if a user lacks edit permissions (for example in tagmanager).

The PR adds some styling hints that the field is disabled, which weren't there in the Scribe editor this replaces.

### Disabled Scribe editor:
![image](https://github.com/guardian/prosemirror-editor/assets/34686302/e101facc-ce5a-46bb-8cf2-e02d5b37d703)

### Disabled prosemirror-editor (`not-allowed` cursor state not visible):
![image](https://github.com/guardian/prosemirror-editor/assets/34686302/cbd9f8cb-170b-4c44-a634-2650acd0cba0)


### Enabled prosemirror-editor:
![image](https://github.com/guardian/prosemirror-editor/assets/34686302/91a2d49d-6865-4259-9ea8-de753b83c2f5)


## How to test

This has been tested locally in tagmanager. If you wish to do the same:

1. Publish this package locally using `yarn yalc` from the root of the project
2. Use [this branch](https://github.com/guardian/tagmanager/pull/500) of `tagmanager` locally.
3. Add this package to tagmanager using `yalc add @guardian/prosemirror-editor`
4. Run tagmanager with `./scripts/setup` then `./scripts/start`
5. Ensure you have tag edit permissions in https://permissions.code.dev-gutools.co.uk/
6. Wait a minute for them to apply. Then, In tagmanager, click an existing tag in the home page and try editing the text.
7. Reverse your permissions in https://permissions.code.dev-gutools.co.uk/ and try editing the tag in Tagmanager again. Does the disabled field act as expected?